### PR TITLE
Add Github Actions workflow to automate release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  PROJECT_PATH: PboExplorer/PboExplorer.csproj
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Restore
+        run: dotnet restore ${{ env.PROJECT_PATH }}
+
+      - name: Build
+        run: >
+          dotnet build ${{ env.PROJECT_PATH }} -c Release --no-restore
+          --self-contained=false -r win-x64 -p:PublishSingleFile=true
+
+      - name: Publish
+        run: >
+          dotnet publish ${{ env.PROJECT_PATH }} -c Release -o Releases --no-build
+          --self-contained=false -r win-x64 -p:PublishSingleFile=true
+
+      - name: Create release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          files: Releases/*.exe

--- a/PboExplorer/PboExplorer.csproj
+++ b/PboExplorer/PboExplorer.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Quality of Life Improvement: Sets up a workflow that creates a release draft on semver-looking tag. 

`marvinpinto/action-automatic-releases` action also generates a changelog for the release from the last tag, which looks like following:
![release_screen](https://user-images.githubusercontent.com/48875452/202844992-c266e0d6-71bb-4291-980d-f21f0ecaba0a.png)
