### PR TITLE
Drag&Drop file extraction

### DIFF
--- a/PboExplorer/MainWindow.xaml
+++ b/PboExplorer/MainWindow.xaml
@@ -66,7 +66,7 @@
             </Grid.ColumnDefinitions>
 
             <TabControl  Grid.Column="0">
-                <TabItem Header="PBO Files" AllowDrop="True" Drop="PboFiles_Drop">
+                <TabItem Header="PBO Files" AllowDrop="True" Drop="PboFiles_Drop" DragOver="PboFiles_DragOver">
                     <TreeView Name="PboView" ItemTemplate="{StaticResource PboTreeTemplate}" SelectedItemChanged="ShowPboEntry" VirtualizingStackPanel.IsVirtualizing="True">
                         <TreeView.ItemContainerStyle>
                             <Style TargetType="TreeViewItem">

--- a/PboExplorer/MainWindow.xaml
+++ b/PboExplorer/MainWindow.xaml
@@ -68,7 +68,11 @@
             <TabControl  Grid.Column="0">
                 <TabItem Header="PBO Files" AllowDrop="True" Drop="PboFiles_Drop">
                     <TreeView Name="PboView" ItemTemplate="{StaticResource PboTreeTemplate}" SelectedItemChanged="ShowPboEntry" VirtualizingStackPanel.IsVirtualizing="True">
-
+                        <TreeView.ItemContainerStyle>
+                            <Style TargetType="TreeViewItem">
+                                <EventSetter Event="MouseMove" Handler="PboEntry_MouseMove"/>
+                            </Style>
+                        </TreeView.ItemContainerStyle>
                     </TreeView>
 
                 </TabItem>

--- a/PboExplorer/MainWindow.xaml.cs
+++ b/PboExplorer/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -671,6 +672,34 @@ namespace PboExplorer
                 // Load other files
                 LoadPboList(lookup[false]);
             }
+        }
+
+        private void PboEntry_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                var element = (FrameworkElement)sender;
+                var dataContext = element.DataContext;
+                if (dataContext is PboEntry entry)
+                {
+                    var tempPath = GetTempFilePath(entry);
+                    var data = new DataObject();
+                    data.SetFileDropList(new StringCollection() { tempPath });
+                    DragDrop.DoDragDrop(element, data, DragDropEffects.Copy);
+                }
+            }
+        }
+
+        private static string GetTempFilePath(PboEntry entry)
+        {
+            string tempFilePath = Path.Combine(Path.GetTempPath(), entry.Name);
+
+            if (!File.Exists(tempFilePath))
+            {
+                entry.Extract(tempFilePath);
+            }
+
+            return tempFilePath;
         }
     }
 }

--- a/PboExplorer/MainWindow.xaml.cs
+++ b/PboExplorer/MainWindow.xaml.cs
@@ -653,6 +653,17 @@ namespace PboExplorer
             return file;
         }
 
+        private void PboFiles_DragOver(object sender, DragEventArgs e)
+        {
+            // Abort drop of extracted files
+            // Drop from Explorer has Copy|Move|Link effects
+            // Drop from app has only Copy
+            if (e.Effects == DragDropEffects.Copy)
+            {
+                e.Effects = DragDropEffects.None;
+                e.Handled = true;
+            }
+        }
         private void PboFiles_Drop(object sender, DragEventArgs e)
         {
             if (e.Data.GetDataPresent(DataFormats.FileDrop))


### PR DESCRIPTION
I thought that the drag&drop feature  is not finished and added PoC implementation for extracting files.

![DragNDrop_Extract](https://user-images.githubusercontent.com/48875452/206930182-8c89f144-7949-43cf-9670-51ae1fa55fc7.gif)


The goal is to enable extraction of files from PBO by dragging them into Windows Explorer, unfortunately there is no straightforward way to drop virtual files in Explorer. The current implementation extracts a file to a temporary folder and then raises a drag event. It may be slow for large files so I limit it to files only (you can not extract directories).

There is an alternative solution [with a temp file and a FileSystemWatcher](https://www.codeproject.com/Articles/23207/Drag-and-Drop-to-Windows-Folder-C) that allows the app to get destination path and then perform extraction (like DayZExtract).This is probably better solution for extracting multiple and/or large files/directories. But it lacks "drag straight to editor" feature.

So what do you think? Should I improve the current implementation 

- [ ] make it asynchronous, 
- [x] fix bug with dragging into PBO FIles tab,
- [ ] possibly add support for directories/multiple files

or implement trick with temp file&FileSystemWatcher (with all checks above)?